### PR TITLE
2.7.0.1 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ foundations in Agda.  The structure of the source code is described below.
 Setup
 -----
 
-The code is loosely broken into `hott-core` and `hott-theorems` Agda libraries.
-This is a fork of the library that is compatible with Agda 2.6.1.
+Agda 2.7.0.1-compatible fork of HoTT-Agda.
+
 To use, you need a recent version of Agda and to include at least the path to `hott-core.agda-lib` in your Agda library list.
-If you download using git remember to check out this branch e.g. using `git clone -b agda-2.6.1-compatible git@github.com:awswan/HoTT-Agda.git`.
+If you download using git remember to check out this branch e.g. using `git clone -b 2.7.0.1-compatible git@github.com:awswan/HoTT-Agda.git`.
+
+The code is loosely broken into `hott-core` and `hott-theorems` Agda libraries.
 The content of `hott-theorems` is not working in this version of the library.
 
 Agda Options

--- a/core/lib/Base.agda
+++ b/core/lib/Base.agda
@@ -545,6 +545,7 @@ instance
   ℕ-reader : FromNat ℕ
   FromNat.in-range ℕ-reader _ = ⊤
   FromNat.read ℕ-reader n = n
+  {-# OVERLAPPABLE ℕ-reader #-}
 
   TLevel-reader : FromNat TLevel
   FromNat.in-range TLevel-reader _ = ⊤

--- a/core/lib/Equivalence2.agda
+++ b/core/lib/Equivalence2.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.types.Sigma

--- a/core/lib/Funext.agda
+++ b/core/lib/Funext.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Base
 open import lib.Function

--- a/core/lib/NConnected.agda
+++ b/core/lib/NConnected.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NType2

--- a/core/lib/NType.agda
+++ b/core/lib/NType.agda
@@ -31,6 +31,7 @@ module _ {i} where
   instance
     has-level-apply-instance : {A : Type i} {n : ℕ₋₂} {x y : A} {{p : has-level (S n) A}} → has-level n (x == y)
     has-level-apply-instance {x = x} {y} {{p}} = has-level-apply p x y
+  -- {-# OVERLAPPABLE has-level-apply-instance #-}
 
   is-contr = has-level -2
   is-prop = has-level -1

--- a/core/lib/NType2.agda
+++ b/core/lib/NType2.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.Equivalence2

--- a/core/lib/groups/FreeAbelianGroup.agda
+++ b/core/lib/groups/FreeAbelianGroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NType2

--- a/core/lib/groups/GeneratedAbelianGroup.agda
+++ b/core/lib/groups/GeneratedAbelianGroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NType2

--- a/core/lib/groups/GeneratedGroup.agda
+++ b/core/lib/groups/GeneratedGroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NType2

--- a/core/lib/groups/Homomorphism.agda
+++ b/core/lib/groups/Homomorphism.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.Equivalence2

--- a/core/lib/groups/HomotopyGroup.agda
+++ b/core/lib/groups/HomotopyGroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NType2

--- a/core/lib/groups/Int.agda
+++ b/core/lib/groups/Int.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NType2

--- a/core/lib/groups/Isomorphism.agda
+++ b/core/lib/groups/Isomorphism.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.Equivalence2

--- a/core/lib/groups/PullbackGroup.agda
+++ b/core/lib/groups/PullbackGroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.types.Cospan

--- a/core/lib/groups/QuotientGroup.agda
+++ b/core/lib/groups/QuotientGroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NType2

--- a/core/lib/groups/Subgroup.agda
+++ b/core/lib/groups/Subgroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NType2

--- a/core/lib/groups/SubgroupProp.agda
+++ b/core/lib/groups/SubgroupProp.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NType2

--- a/core/lib/groups/TruncationGroup.agda
+++ b/core/lib/groups/TruncationGroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.types.Group

--- a/core/lib/two-semi-categories/FundamentalCategory.agda
+++ b/core/lib/two-semi-categories/FundamentalCategory.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.types.Truncation

--- a/core/lib/types/BAut.agda
+++ b/core/lib/types/BAut.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NType2

--- a/core/lib/types/CRing.agda
+++ b/core/lib/types/CRing.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.types.Group

--- a/core/lib/types/Choice.agda
+++ b/core/lib/types/Choice.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.types.Coproduct

--- a/core/lib/types/Coproduct.agda
+++ b/core/lib/types/Coproduct.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.types.Bool

--- a/core/lib/types/Cover.agda
+++ b/core/lib/types/Cover.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics renaming (pt to pt⊙)
 open import lib.NConnected

--- a/core/lib/types/EilenbergMacLane1/Core.agda
+++ b/core/lib/types/EilenbergMacLane1/Core.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NType2

--- a/core/lib/types/EilenbergMacLane1/Recursion.agda
+++ b/core/lib/types/EilenbergMacLane1/Recursion.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NType2

--- a/core/lib/types/Group.agda
+++ b/core/lib/types/Group.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.types.Coproduct

--- a/core/lib/types/GroupSet.agda
+++ b/core/lib/types/GroupSet.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NType2

--- a/core/lib/types/Nat.agda
+++ b/core/lib/types/Nat.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Base
 open import lib.Function

--- a/core/lib/types/NatColim.agda
+++ b/core/lib/types/NatColim.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NConnected
@@ -32,6 +32,21 @@ module _ {i} {D : ℕ → Ptd i} where
   ⊙ℕColim : (d : (n : ℕ) → (D n ⊙→ D (S n))) → Ptd i
   ⊙ℕColim d = ⊙[ ℕColim (fst ∘ d) , ncin 0 (pt (D 0)) ]
 
+-- Define this initial part of ℕColimElim first, to make the REWRITE declaration
+-- go through (in Agda 2.7.0.1) ~Josh
+module ℕColimElim-in {i} {D : ℕ → Type i} (d : (n : ℕ) → D n → D (S n))
+  {j} {P : ℕColim d → Type j}
+  (ncin* : (n : ℕ) (x : D n) → P (ncin n x))
+  (ncglue* : (n : ℕ) (x : D n)
+    → ncin* n x == ncin* (S n) (d n x) [ P ↓ ncglue n x ])
+  where
+
+  postulate  -- HIT
+    f : Π (ℕColim d) P
+    ncin-β : ∀ n x → f (ncin n x) ↦ ncin* n x
+
+{-# REWRITE ℕColimElim-in.ncin-β #-}
+
 module _ {i} {D : ℕ → Type i} (d : (n : ℕ) → D n → D (S n)) where
 
   module ℕColimElim {j} {P : ℕColim d → Type j}
@@ -39,11 +54,7 @@ module _ {i} {D : ℕ → Type i} (d : (n : ℕ) → D n → D (S n)) where
     (ncglue* : (n : ℕ) (x : D n)
       → ncin* n x == ncin* (S n) (d n x) [ P ↓ ncglue n x ])
     where
-
-    postulate  -- HIT
-      f : Π (ℕColim d) P
-      ncin-β : ∀ n x → f (ncin n x) ↦ ncin* n x
-    {-# REWRITE ncin-β #-}
+    open ℕColimElim-in d ncin* ncglue* public
 
     postulate  -- HIT
       ncglue-β : (n : ℕ) (x : D n) → apd f (ncglue n x) == ncglue* n x

--- a/core/lib/types/PathSet.agda
+++ b/core/lib/types/PathSet.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.types.TLevel

--- a/core/lib/types/Pullback.agda
+++ b/core/lib/types/Pullback.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NType

--- a/core/lib/types/SetQuotient.agda
+++ b/core/lib/types/SetQuotient.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.Relation

--- a/core/lib/types/Suspension.agda
+++ b/core/lib/types/Suspension.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.NConnected

--- a/core/lib/types/TLevel.agda
+++ b/core/lib/types/TLevel.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Base
 open import lib.PathGroupoid

--- a/core/lib/types/Truncation.agda
+++ b/core/lib/types/Truncation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import lib.Basics
 open import lib.types.TLevel

--- a/theorems/cohomology/Theory.agda
+++ b/theorems/cohomology/Theory.agda
@@ -110,7 +110,7 @@ record CohomologyTheory i : Type (lsucc i) where
 
   CEl-emap : (n : ℤ) {X Y : Ptd i} → X ⊙≃ Y → Group.El (C n Y) ≃ Group.El (C n X)
   CEl-emap n ⊙eq = equiv (CEl-fmap n (⊙–> ⊙eq)) (CEl-fmap n (⊙<– ⊙eq)) to-from from-to where
-    abstract
+    -- abstract
       to-from = λ x → ! (CEl-fmap-∘ n (⊙<– ⊙eq) (⊙–> ⊙eq) x)
                     ∙ ap (λ f → CEl-fmap n f x) (⊙λ= (⊙<–-inv-l ⊙eq))
                     ∙ CEl-fmap-idf n x
@@ -124,7 +124,7 @@ record CohomologyTheory i : Type (lsucc i) where
 
   C-emap : (n : ℤ) {X Y : Ptd i} → X ⊙≃ Y → C n Y ≃ᴳ C n X
   C-emap n ⊙eq = ≃-to-≃ᴳ (CEl-emap n ⊙eq) lemma
-    where abstract lemma = GroupHom.pres-comp (C-fmap n (⊙–> ⊙eq))
+    where lemma = GroupHom.pres-comp (C-fmap n (⊙–> ⊙eq))
 
   C-isemap = CEl-isemap
 
@@ -192,6 +192,7 @@ record CohomologyTheory i : Type (lsucc i) where
         =⟨ GroupHom.pres-ident (C-fmap n (⊙cst {X = X} {Y = ⊙LU})) ⟩
       Cident n X ∎
       where
+      ⊙LU : Ptd i
       ⊙LU = ⊙Lift {j = i} ⊙Unit
 
     C-fmap-const : (n : ℤ) {X Y : Ptd i} {f : X ⊙→ Y}

--- a/theorems/groups/CoefficientExtensionality.agda
+++ b/theorems/groups/CoefficientExtensionality.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import HoTT
 
@@ -429,4 +429,4 @@ module _ where
 
   Fin→-has-finite-support : ∀ {I} (f : Fin I → ℤ) → has-finite-support Fin-has-dec-eq f
   Fin→-has-finite-support {I} f = FormalSum-sum f , lemma
-    where abstract lemma = λ <I → ! (ap (λ fs → FormalSum-coef Fin-has-dec-eq fs <I) (FormalSum-sum'-β 0 I f) ∙ Word-coef-sum' 0 f <I)
+    where lemma = λ <I → ! (ap (λ fs → FormalSum-coef Fin-has-dec-eq fs <I) (FormalSum-sum'-β 0 I f) ∙ Word-coef-sum' 0 f <I)

--- a/theorems/groups/ProductRepr.agda
+++ b/theorems/groups/ProductRepr.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import HoTT
 

--- a/theorems/groups/ReducedWord.agda
+++ b/theorems/groups/ReducedWord.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search --instance-search-depth=10 #-}
 
 open import HoTT
 
@@ -47,8 +47,8 @@ module groups.ReducedWord {i} {A : Type i} (dec : has-dec-eq A) where
   is-reduced-is-prop {nil}                 = ⟨⟩
   is-reduced-is-prop {x    :: nil}         = ⟨⟩
   is-reduced-is-prop {inl x :: inl y :: l} = is-reduced-is-prop {inl y :: l}
-  is-reduced-is-prop {inl x :: inr y :: l} = ⟨⟩ where instance _ = is-reduced-is-prop {inr y :: l}
-  is-reduced-is-prop {inr x :: inl y :: l} = ⟨⟩ where instance _ = is-reduced-is-prop {inl y :: l}
+  is-reduced-is-prop {inl x :: inr y :: l} = let instance _ = is-reduced-is-prop {inr y :: l} in ⟨⟩
+  is-reduced-is-prop {inr x :: inl y :: l} = let instance _ = is-reduced-is-prop {inl y :: l} in ⟨⟩
   is-reduced-is-prop {inr x :: inr y :: l} = is-reduced-is-prop {inr y :: l}
 
   is-reduced-prop : SubtypeProp (Word A) i

--- a/theorems/groups/SuspAdjointLoop.agda
+++ b/theorems/groups/SuspAdjointLoop.agda
@@ -16,7 +16,6 @@ module groups.SuspAdjointLoop {i} where
         (GroupStructure.comp (⊙→Ω-group-structure (⊙Susp X) Y))
         (GroupStructure.comp (⊙→Ω-group-structure X (⊙Ω Y)))
         (–> (A.eq X (⊙Ω Y)))
-    abstract
       pres-comp h₁ h₂ =
         B.nat-cod h₁ h₂ ⊙Ω-∙
         ∙ ap (_⊙∘ ⊙fanout (–> (A.eq X (⊙Ω Y)) h₁) (–> (A.eq X (⊙Ω Y)) h₂))
@@ -57,8 +56,8 @@ module groups.SuspAdjointLoop {i} where
     Trunc-⊙→Ω-iso-Trunc-⊙→Ω-nat-dom : {X Y : Ptd i} (f : X ⊙→ Y) (Z : Ptd i)
       → fst (Trunc-⊙→Ω-iso-Trunc-⊙→Ω X Z) ∘ᴳ Trunc-⊙→Ω-group-fmap-dom (⊙Susp-fmap f) Z
         == Trunc-⊙→Ω-group-fmap-dom f (⊙Ω Z) ∘ᴳ fst (Trunc-⊙→Ω-iso-Trunc-⊙→Ω Y Z)
-    Trunc-⊙→Ω-iso-Trunc-⊙→Ω-nat-dom f Z = group-hom= $ λ= $ Trunc-elim
-      (λ g → ap [_] (! (A.nat-dom f (⊙Ω Z) g)))
+    Trunc-⊙→Ω-iso-Trunc-⊙→Ω-nat-dom {X} f Z =
+      group-hom= $ λ= $ Trunc-elim (λ g → ap [_] (! (A.nat-dom f (⊙Ω Z) g)))
 
   module _ (X Y : Ptd i) where
 

--- a/theorems/groups/ToOmega.agda
+++ b/theorems/groups/ToOmega.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import HoTT
 

--- a/theorems/homotopy/ConstantToSetExtendsToProp.agda
+++ b/theorems/homotopy/ConstantToSetExtendsToProp.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import HoTT
 

--- a/theorems/homotopy/EM1HSpace.agda
+++ b/theorems/homotopy/EM1HSpace.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import HoTT
 open import homotopy.HSpace

--- a/theorems/homotopy/EilenbergMacLane.agda
+++ b/theorems/homotopy/EilenbergMacLane.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search --instance-search-depth=3 #-}
 
 open import HoTT
 open import homotopy.HSpace renaming (HSpaceStructure to HSS)

--- a/theorems/homotopy/EilenbergMacLane1.agda
+++ b/theorems/homotopy/EilenbergMacLane1.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search --instance-search-depth=2 #-}
 
 open import HoTT
 

--- a/theorems/homotopy/FinSet.agda
+++ b/theorems/homotopy/FinSet.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import HoTT
 import homotopy.ConstantToSetExtendsToProp as ConstExt

--- a/theorems/homotopy/LoopSpaceCircle.agda
+++ b/theorems/homotopy/LoopSpaceCircle.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import HoTT
 

--- a/theorems/homotopy/Pi2HSusp.agda
+++ b/theorems/homotopy/Pi2HSusp.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import HoTT
 open import homotopy.HSpace renaming (HSpaceStructure to HSS)

--- a/theorems/homotopy/PinSn.agda
+++ b/theorems/homotopy/PinSn.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --overlapping-instances #-}
+{-# OPTIONS --without-K --rewriting --backtracking-instance-search #-}
 
 open import HoTT
 open import homotopy.CircleHSpace


### PR DESCRIPTION
I've updated the `core/` files to work with the new instance search mechanism in Agda 2.7.0.1, and begun porting some of the `theorems/` folder.

This is a merge request into the `agda-2.6.1-compatible` branch since PRs can only merge into existing branches.
Would it be worth having a separate branch for 2.7.0.1 since the way instances work is breakingly different between the 2.6.* and 2.7.* Agda versions?